### PR TITLE
Move to epocxy 0.9.8 to sync with ttserver/uffda

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,6 @@
 {deps,
  [{parse_trans, ".*", {git, "git@github.com:uwiger/parse_trans.git", "master"}},
   {lager,       ".*", {git, "git@github.com:basho/lager.git", "master"}},
-  {epocxy,   "0.9.7", {git, "git@github.com:duomark/dk_cxy.git", {tag, "0.9.7"}}},
+  {epocxy,   "0.9.8", {git, "git@github.com:duomark/dk_cxy.git", {tag, "0.9.8"}}},
   {validerl,    ".*", {git, "https://github.com/HernanRivasAcosta/validerl.git",
                        "master"}}]}.


### PR DESCRIPTION
While moving ttserver to 0.9.8 so that it could incorporate Uffda, I discovered that kafkerl needs to change at the same time for compatibility. This merge has to be coordinated, or should be made with a new version tag.
