### PR TITLE
TS-5500 Validate that the kafka-driven disconnects works correct with kafkerl

### DIFF
--- a/src/kafkerl_broker_connection.erl
+++ b/src/kafkerl_broker_connection.erl
@@ -105,9 +105,7 @@ handle_info({connected, Socket}, State) ->
     handle_flush(State#state{socket = Socket});
 handle_info(connection_timeout, State) ->
     {stop, {error, unable_to_connect}, State};
-handle_info({tcp_closed, _Socket}, State = #state{name = Name,
-    address = {Host, Port}}) ->
-    _ = lager:warning("~p lost connection to ~p:~p", [Name, Host, Port]),
+handle_info({tcp_closed, _Socket}, State = #state{}) ->
     NewState = handle_tcp_close(State),
     {noreply, NewState};
 handle_info({tcp, _Socket, Bin}, State) ->


### PR DESCRIPTION
see the comment in the ticket. 